### PR TITLE
Schema for context data and two examples of contexts in JSon

### DIFF
--- a/examples/sampleContact.json
+++ b/examples/sampleContact.json
@@ -10,25 +10,29 @@
             {
                 "format": "fdc3.Contact",
                 "version": "0.0.1",
-                "itemData": {                       
+                "itemData": {
+                    "firstName": "Fred",
+                    "lastName": "Smith",
+                    "email": "fred@smith.com"                       
                 }
             },
             {
                 "format": "com.symphony.Contact",
                 "version": "0.0.1",
                 "itemData": {
-                    "ticker": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "name": "Fred Smith",
+                    "org":"Independent",
+                    "symphonyhandle": "fred-smith42"                        
                 }
             },
             {
                 "format": "com.microsoft.Outlook.Contact",
                 "version": "0.0.1",
                 "itemData": {
-                    "ticker": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "firstName": "Fred",
+                    "lastName": "Smith",
+                    "email": "fred@smith.com",
+                    "outlookId": "12345678"                       
                 }
             },
             {

--- a/examples/sampleContact.json
+++ b/examples/sampleContact.json
@@ -1,0 +1,44 @@
+{
+    "objectType": "fdc3-context",
+    "definition": "https://fdc3.org/ContextSchema.json",
+    "version": "0.0.2",
+    "contextItems": [
+        {
+        "displayName": "Fred Smith",
+        "displayType": "Contact",
+        "data": [
+            {
+                "format": "fdc3.Contact",
+                "version": "0.0.1",
+                "itemData": {                       
+                }
+            },
+            {
+                "format": "com.symphony.Contact",
+                "version": "0.0.1",
+                "itemData": {
+                    "ticker": "",
+                    "symbology.entity":"",
+                    "regionalticker": ""                        
+                }
+            },
+            {
+                "format": "com.microsoft.Outlook.Contact",
+                "version": "0.0.1",
+                "itemData": {
+                    "ticker": "",
+                    "symbology.entity":"",
+                    "regionalticker": ""                        
+                }
+            },
+            {
+                "format": "custom.tick42.demo.Contact",
+                "version": "0.0.1",
+                "itemData": {
+                    "!!!!": ""                        
+                }
+            }
+        ] 
+    }
+    ]
+  }

--- a/examples/sampleInstrument.json
+++ b/examples/sampleInstrument.json
@@ -30,21 +30,24 @@
                 }
             },
             {
-                "format": "figi.???",
+                "format": "com.openfigi.Equity",
                 "version": "0.0.1",
                 "itemData": {
-                    "ticker": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "Name": "Apple Inc",
+                    "Ticker":"AAPL",
+                    "ExchangeCode": "XN",
+                    "FIGI": "BBG000N89284",
+                    "FIGI Composite": "BBG000N88V36",
+                    "SecurityType": "Equity.CommonStock"
                 }
             },
             {
                 "format": "custom.tick42.demo.Instrument",
                 "version": "0.0.1",
                 "itemData": {
-                    "!!!!": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "marketDataSource": "Reuters",
+                    "Ticker":"AAPL",
+                    "marketDataTicker": "AAPL.N"  
                 }
             }
         ]

--- a/examples/sampleInstrument.json
+++ b/examples/sampleInstrument.json
@@ -47,7 +47,8 @@
                 "itemData": {
                     "marketDataSource": "Reuters",
                     "Ticker":"AAPL",
-                    "marketDataTicker": "AAPL.N"  
+                    "marketDataTicker": "AAPL.N",
+                    "demoInstrumentId": "567890"  
                 }
             }
         ]

--- a/examples/sampleInstrument.json
+++ b/examples/sampleInstrument.json
@@ -1,0 +1,53 @@
+{
+    "objectType": "fdc3-context",
+    "definition": "https://fdc3.org/ContextSchema.json",
+    "version": "0.0.2",
+    "contextItems": [
+        {
+        "displayName": "Apple",
+        "displayType": "Equity",
+        "data": [
+            {
+                "format": "fdc3.security",
+                "version": "0.0.1",
+                "itemData": {
+                    "ISIN": "",
+                    "CUSIP": "",
+                    "BBG": "",
+                    "SEDOL": "",
+                    "ticker": "",
+                    "com.factset.symbology.entity":"",
+                    "com.factset.symbology.regionalticker": ""                        
+                }
+            },
+            {
+                "format": "com.factset.security",
+                "version": "0.0.1",
+                "itemData": {
+                    "ticker": "",
+                    "symbology.entity":"",
+                    "regionalticker": ""                        
+                }
+            },
+            {
+                "format": "figi.???",
+                "version": "0.0.1",
+                "itemData": {
+                    "ticker": "",
+                    "symbology.entity":"",
+                    "regionalticker": ""                        
+                }
+            },
+            {
+                "format": "custom.tick42.demo.Instrument",
+                "version": "0.0.1",
+                "itemData": {
+                    "!!!!": "",
+                    "symbology.entity":"",
+                    "regionalticker": ""                        
+                }
+            }
+        ]
+        }
+    ]
+  }

--- a/schema/ContextSchema.json
+++ b/schema/ContextSchema.json
@@ -1,0 +1,84 @@
+{
+    "$id": "http://finos.fdc3.com/context.json",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "description": "Schema describing the FDC3 Context data item.",
+    "title": "Context",
+    "type": "object",
+    "required": ["objectType", "contextItems"], 
+    "properties": {
+        "objectType": {
+            "type": "string",
+            "description": "Confirm the JSon object type. The only valid value is fdc3-context.TODO:Misho how do we specify this in schema ?",
+            "enum": ["fdc3-context"]
+        },
+        "definition": {
+            "type": "string",
+            "description": "URI for the schema ?",
+            "default": "false"
+        },
+        "version": {
+            "type": "string",
+            "description": "TODO: How is this used, is it identifying which version of the Context Schema this definition is using. If so how are versions managed. TODO: Should we have a default ?",
+            "default": "false"
+        },
+         "contextItems": {
+            "description": "A Context can hold one or more data items. The most common scenario is a single item like a client or an Instrument. Where multiple items are present, there is an open question whether they all MUST be the same type",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "#/definitions/contextItem"
+            },
+            "additionalProperties": false
+         }
+    },
+    "definitions": {
+        "contextItem": {
+            "description": "A single data item in a Context. The data item e.g. the Client or the Instrument can be described using 1 or more formats. Each format is identified by a type name. A single format may contain multiple fields to describe the Instrument for example holding the Reuters, Bloomberg and ISIN codes for an Equity. However different format types may have different names for these fields and there may also be rules about which fields are mandatory. ",
+            "type": "object",
+            "required": ["displayName", "data"],
+            "properties": {
+                "displayName": {
+                    "description": "A simple name for this item  e.g. Apple, AAPL or Fred Smith. The name is unlikely to be able to be useful for any processing, but it is useful to show to the user or use in debug/log messages",
+                    "type": "string"
+                },                
+                "displayType": {
+                    "description": "A short hand 'meta' name for this item type that is useful to show to the user or use in debug/log messages e.g.  Instrument, or Equity or Contact. It does not correspond to a formal context type. ",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The actual data that defines/describes the Item. This can be presented in one or more formats, which allows different groups, including in-house development teams, to define their own data sets without worrying about field name clashes with other groups",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/contextItemFormat"
+                    }
+                }
+            },
+            "additionalProperties": false
+         },
+
+         "contextItemFormat": {
+            "description": "The data that describes/defines a context item in a particular format",
+            "type": "object",
+            "required": ["format", "itemData"],
+            "properties": {
+                "format": {
+                    "type": "string",
+                    "description": "The name of this format i.e. the format type. This uses a '.' notiation e.g. fdc3.Contact or org.symphony.Contact ",
+                    "default": "false"
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Optional format type version  ",
+                    "default": "false"
+                },
+                "itemData": {
+                    "type": "object",
+                    "description": "The data that describes the field, typically a JSon object but data type depends on the format",
+                    "default": "false"
+                }
+            }
+         }
+    },
+    "additionalProperties": false
+}

--- a/schema/ContextSchema.json
+++ b/schema/ContextSchema.json
@@ -2,7 +2,7 @@
     "$id": "http://finos.fdc3.com/context.json",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "description": "Schema describing the FDC3 Context data item.",
-    "title": "Context",
+    "title": "FDC3.Context",
     "type": "object",
     "required": ["objectType", "contextItems"], 
     "properties": {


### PR DESCRIPTION
This Pull request moves the Context data specification to match up with the Intent WG definitions by allowing a data item (e.g. Instrument or Contact) to have multiple named formats (instead of just having a single data set with multiple field names).

This structure allows applications to register an Intent to only be relevant for a particular format of Instrument (for example only showing in-house position for an instrument if the Context holds a particular format of an Instrument).

The Pull Request provides a JSon schema and two sample data files for this proposal.