### PR TITLE
New context format with JSon schema and two sample data files

### DIFF
--- a/examples/sampleContact.json
+++ b/examples/sampleContact.json
@@ -10,25 +10,29 @@
             {
                 "format": "fdc3.Contact",
                 "version": "0.0.1",
-                "itemData": {                       
+                "itemData": {
+                    "firstName": "Fred",
+                    "lastName": "Smith",
+                    "email": "fred@smith.com"                       
                 }
             },
             {
                 "format": "com.symphony.Contact",
                 "version": "0.0.1",
                 "itemData": {
-                    "ticker": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "name": "Fred Smith",
+                    "org":"Independent",
+                    "symphonyhandle": "fred-smith42"                        
                 }
             },
             {
                 "format": "com.microsoft.Outlook.Contact",
                 "version": "0.0.1",
                 "itemData": {
-                    "ticker": "",
-                    "symbology.entity":"",
-                    "regionalticker": ""                        
+                    "firstName": "Fred",
+                    "lastName": "Smith",
+                    "email": "fred@smith.com",
+                    "outlookId": "12345678"                       
                 }
             },
             {

--- a/examples/sampleInstrument.json
+++ b/examples/sampleInstrument.json
@@ -47,7 +47,8 @@
                 "itemData": {
                     "marketDataSource": "Reuters",
                     "Ticker":"AAPL",
-                    "marketDataTicker": "AAPL.N"  
+                    "marketDataTicker": "AAPL.N",
+                    "demoInstrumentId": "567890"  
                 }
             }
         ]

--- a/schema/ContextSchema.json
+++ b/schema/ContextSchema.json
@@ -2,7 +2,7 @@
     "$id": "http://finos.fdc3.com/context.json",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "description": "Schema describing the FDC3 Context data item.",
-    "title": "Context",
+    "title": "FDC3.Context",
     "type": "object",
     "required": ["objectType", "contextItems"], 
     "properties": {


### PR DESCRIPTION
This Pull request moves the Context data specification to match up with the current Intent definitions by allowing a data item (e.g. Instrument or Contact) to have multiple named formats (instead of just having a single data set with multiple field names).

This structure allows applications to register an Intent to only be relevant for a particular format of Instrument (for example only showing in-house position for an instrument if the Context holds the in-house instrument format )
NB An application Intent can be offered for multiple formats.

The Pull Request provides a JSon schema and two sample data files for this proposal.
